### PR TITLE
Implement continuous integration with Circle CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,0 @@
-language: ruby
-rvm:
-  - 2.3.0
-before_install: gem install bundler -v 1.11.2

--- a/Gemfile
+++ b/Gemfile
@@ -2,5 +2,3 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in kolekti_cc_phpmd.gemspec
 gemspec
-
-gem 'codeclimate', github: 'codeclimate/codeclimate'

--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,5 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in kolekti_cc_phpmd.gemspec
 gemspec
+
+gem 'codeclimate', github: 'codeclimate/codeclimate'

--- a/circle.yml
+++ b/circle.yml
@@ -3,5 +3,5 @@ machine:
     - docker
 
 dependencies:
-  override:
+  pre:
     - docker pull codeclimate/codeclimate

--- a/circle.yml
+++ b/circle.yml
@@ -3,5 +3,8 @@ machine:
     - docker
 
 dependencies:
-  pre:
+  post:
     - docker pull codeclimate/codeclimate
+    - docker pull codeclimate/codeclimate-phpmd:latest
+    - curl -L https://github.com/codeclimate/codeclimate/archive/master.tar.gz | tar xvz
+    - cd codeclimate-* && sudo make install

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,7 @@
+machine:
+  services:
+    - docker
+
+dependencies:
+  override:
+    - docker pull codeclimate/codeclimate

--- a/circle.yml
+++ b/circle.yml
@@ -3,8 +3,8 @@ machine:
     - docker
 
 dependencies:
-  post:
-    - docker pull codeclimate/codeclimate
+  pre:
+    # Workaround: replace docker command with one that ignores the --rm and --cap-drop options
+    - "wget -O - 'https://gist.githubusercontent.com/danielkza/1cd5b917bbf216965298/raw' | sudo tee /usr/local/bin/docker"
+    - sudo chmod 755 /usr/local/bin/docker
     - docker pull codeclimate/codeclimate-phpmd:latest
-    - curl -L https://github.com/codeclimate/codeclimate/archive/master.tar.gz | tar xvz
-    - cd codeclimate-* && sudo make install

--- a/circle.yml
+++ b/circle.yml
@@ -5,6 +5,6 @@ machine:
 dependencies:
   pre:
     # Workaround: replace docker command with one that ignores the --rm and --cap-drop options
-    - "wget -O - 'https://gist.githubusercontent.com/danielkza/1cd5b917bbf216965298/raw' | sudo tee /usr/local/bin/docker"
+    - sudo cp scripts/docker-circle-ci /usr/local/bin/docker
     - sudo chmod 755 /usr/local/bin/docker
     - docker pull codeclimate/codeclimate-phpmd:latest

--- a/kolekti_cc_phpmd.gemspec
+++ b/kolekti_cc_phpmd.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "codeclimate", "~>0.21"
+  spec.add_dependency "codeclimate", "~>0.23"
   spec.add_dependency "kolekti", "~> 1.0"
 
   spec.add_development_dependency "bundler", "~> 1.11"

--- a/lib/kolekti/cc_phpmd/collector.rb
+++ b/lib/kolekti/cc_phpmd/collector.rb
@@ -26,7 +26,7 @@ module Kolekti
         # owned by root (that behavior is fortunately deprecated starting with Docker 1.9)
         create_cc_dir
 
-        system('codeclimate version', [:out, :err] => '/dev/null') ? true : false
+        system('docker inspect codeclimate/codeclimate-phpmd', [:out, :err] => '/dev/null') ? true : false
       end
 
       def initialize

--- a/scripts/docker-circle-ci
+++ b/scripts/docker-circle-ci
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+declare -a args=()
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --rm) ;;
+        --rm=true) ;;
+        --cap-drop) shift ;;
+        --cap-drop=*) ;;
+        *) args+=("$1") ;;
+    esac
+    shift
+done
+
+exec /usr/bin/docker "${args[@]}"


### PR DESCRIPTION
Some workarounds were needed to get Docker to behave in the environment with limited privileges, such as ignoring `--rm` and `--cap-drop` options.

Availability detection was changed from looking for the `codeclimate` script to checking the docker image, as we were never actually using the script for anything (we use the gem directly).

It was also necessary to set the codeclimate gem to the git master until the Safe YAML fix is released.
