### PR TITLE
Fix parser write return value

### DIFF
--- a/CHANGELOG.rdoc
+++ b/CHANGELOG.rdoc
@@ -1,0 +1,30 @@
+= Revision history for Kolekti Codeclimate PHPMD
+
+The Kolekti Codeclimate PHPMD gem implements a collector for PHP issues using Codeclimate with Kolekti
+
+== Unreleased
+
+Fix parser write return value
+
+== v0.0.1 - 23/03/2016
+
+Initial release
+
+===
+
+Kolekti Codeclimate PHPMD.
+Copyright (C) 2015  The Mezuro Team
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+

--- a/lib/kolekti/cc_phpmd/parser.rb
+++ b/lib/kolekti/cc_phpmd/parser.rb
@@ -18,10 +18,10 @@ module Kolekti
            raise Kolekti::CollectorError.new("Failed parsing CodeClimate JSON data")
          end
 
-         return if jsdata["type"] != "issue"
+         return true if jsdata["type"] != "issue"
 
          metric_configuration = @wanted_metric_configurations[jsdata["check_name"]]
-         return if metric_configuration.nil?
+         return true if metric_configuration.nil?
 
          location = jsdata["location"] || {}
          path = location["path"]
@@ -33,6 +33,7 @@ module Kolekti
 
          @persistence_strategy.create_hotspot_metric_result(metric_configuration, module_name_for_path(path),
                                                             line_number, message)
+         true
       end
 
       def failed(output)

--- a/spec/kolekti/cc_phpmd/parser_spec.rb
+++ b/spec/kolekti/cc_phpmd/parser_spec.rb
@@ -34,7 +34,7 @@ describe Kolekti::CcPhpMd::Parser do
 
         it 'is expected to ignore the entry' do
           expect(JSON).to receive(:parse).with(data) { jsdata }
-          subject.write(data)
+          expect(subject.write(data)).to be_truthy
           expect(persistence_strategy.hotspot_metric_results).to be_empty
         end
       end
@@ -44,7 +44,7 @@ describe Kolekti::CcPhpMd::Parser do
 
         it 'is expected to ignore the entry' do
           expect(JSON).to receive(:parse).with(data) { jsdata }
-          subject.write(data)
+          expect(subject.write(data)).to be_truthy
           expect(persistence_strategy.hotspot_metric_results).to be_empty
         end
       end
@@ -71,9 +71,9 @@ describe Kolekti::CcPhpMd::Parser do
          }
        }
 
-        it 'is expected to raise a CollectorError' do
+        it 'is expected to generate a result' do
           expect(JSON).to receive(:parse).with(data) { jsdata }
-          subject.write(data)
+          expect(subject.write(data)).to be_truthy
           expect(persistence_strategy.hotspot_metric_results).to include({
             :line => 1,
             :message => "description",


### PR DESCRIPTION
It must be truthy in any case that is not an error (including ignoring
the data),  or Codeclimate will abort the container.

Signed-off-by: Eduardo Araújo <duduktamg@hotmail.com>